### PR TITLE
Sync LICENSE file to same as in metadata.json (Apache-2.0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,13 @@
-Copyright (c) 2014 OpenTable, Inc.
+   Copyright 2014 OpenTable, Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,3 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
 # == Class graphite_powershell::config
 #
 # This private class is called from `graphite_powershell`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,3 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
 # == Class: graphite_powershell
 #
 # Module to send metrics to graphite from windows

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,3 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
 # == Class graphite_powershell::install
 #
 # This private class is meant to be called from `graphite_powershell`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,3 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
 # == Class graphite_powershell::params
 #
 # This private class is meant to be called from `graphite_powershell`

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,3 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
 # == Class graphite_powershell::service
 #
 # This private class is meant to be called from `graphite_powershell`


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time